### PR TITLE
generalizing wedge to UniformScaling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumDots"
 uuid = "312194fd-fec5-4b07-ba1c-a40d7013a56a"
 authors = ["Viktor Svensson, William Samuelson"]
-version = "0.9.4"
+version = "0.9.5"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/src/wedge.jl
+++ b/src/wedge.jl
@@ -59,13 +59,13 @@ end
 Compute the wedge product of two matrices `m1` and `m2` with respect to the fermion bases `b1` and `b2`, respectively. Return a matrix in the fermion basis `b3`, which defaults to the wedge product of `b1` and `b2`.
 
 # Arguments
-- `m1::AbstractMatrix{T1}`: The first matrix.
+- `m1::Union{AbstractMatrix{T1}, UniformScaling{T1}}`: The first matrix.
 - `b1::FermionBasis{M1}`: The fermion basis associated with `m1`.
-- `m2::AbstractMatrix{T2}`: The second matrix.
+- `m2::Union{AbstractMatrix{T2}, UniformScaling{T2}}`: The second matrix.
 - `b2::FermionBasis{M2}`: The fermion basis associated with `m2`.
 - `b3::FermionBasis`: The fermion basis associated with the resulting matrix. (optional)
 """
-function wedge(m1::AbstractMatrix{T1}, b1::FermionBasis{M1}, m2::AbstractMatrix{T2}, b2::FermionBasis{M2}, b3::FermionBasis=wedge(b1, b2)) where {M1,M2,T1,T2}
+function wedge(m1::Union{AbstractMatrix{T1}, UniformScaling{T1}}, b1::FermionBasis{M1}, m2::Union{AbstractMatrix{T2}, UniformScaling{T2}}, b2::FermionBasis{M2}, b3::FermionBasis=wedge(b1, b2)) where {M1,M2,T1,T2}
     M3 = length(b3)
     check_wedge_basis_compatibility(b1, b2, b3)
     T3 = promote_type(T1, T2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -289,8 +289,11 @@ end
         vals2, vecs2 = eigen(H2)
         H3 = Matrix(0.5b3[1]' * b3[1] - 0.1b3[2]' * b3[2] + 0.3b3[3]' * b3[3] + (b3[2]' * b3[3] + hc))
         vals3, vecs3 = eigen(H3)
-        H3w = wedge(H1, b1, one(H2), b2, b3) + wedge(one(H1), b1, H2, b2, b3)
+
+        # test wedging with I (UniformScaling)
+        H3w = wedge(H1, b1, I, b2, b3) + wedge(I, b1, H2, b2, b3)
         @test H3w == H3
+        @test wedge(I, b1, I, b2, b3) == one(H3)
 
         vals3w = map(sum, Base.product(vals1, vals2)) |> vec
         p = sortperm(vals3w)
@@ -326,7 +329,8 @@ end
         params12 = (; μ=[params1.μ, params1.μ, params2.μ, params2.μ], t=[params1.t, 0, params2.t, 0], Δ=[params1.Δ, params1.Δ, params2.Δ, params2.Δ], V=[params1.V, 0, params2.V, 0], θ=[0, θ1, 0, θ2], ϕ=[params1.ϕ, params1.ϕ, params2.ϕ, params2.ϕ], h=[params1.h, params1.h, params2.h, params2.h], U=[params1.U, params1.U, params2.U, params2.U], Δ1=[params1.Δ1, 0, params2.Δ1, 0])
         H1 = QuantumDots.BD1_hamiltonian(b1; params1...)
         H2 = QuantumDots.BD1_hamiltonian(b2; params2...)
-        H12w = wedge(H1, b1, one(H2), b2, b12w) + wedge(one(H1), b1, H2, b2, b12w)
+
+        H12w = wedge(H1, b1, I, b2, b12w) + wedge(I, b1, H2, b2, b12w)
         H12 = Matrix(QuantumDots.BD1_hamiltonian(b12; params12...))
 
         v12w = wedge(eigvecs(Matrix(H1))[:, 1], b1, eigvecs(Matrix(H2))[:, 1], b2, b12w)


### PR DESCRIPTION
Added compatibility to use UniformScaling unity matrix in wedge. Check if you think it's ok and that the tests cover it. 