### PR TITLE
generalize wedge

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumDots"
 uuid = "312194fd-fec5-4b07-ba1c-a40d7013a56a"
 authors = ["Viktor Svensson, William Samuelson"]
-version = "0.11.5"
+version = "0.12.0"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/src/fock.jl
+++ b/src/fock.jl
@@ -55,14 +55,14 @@ end
 _bit(f, k) = Bool((f >> (k - 1)) & 1)
 function phase_factor(focknbr1, focknbr2, subinds::NTuple)::Int
     bitmask = focknbr_from_site_indices(subinds)
-    prod(i -> (jwstring(i, bitmask & focknbr1) * jwstring(i, bitmask & focknbr2))^_bit(focknbr2, i), subinds)
+    prod(i -> (jwstring_left(i, bitmask & focknbr1) * jwstring_left(i, bitmask & focknbr2))^_bit(focknbr2, i), subinds)
 end
 function phase_factor(focknbr1, focknbr2, N)::Int
     prod(_phase_factor(focknbr1, focknbr2, i) for i in 1:N)
 end
 
 function _phase_factor(focknbr1, focknbr2, i)::Int
-    _bit(focknbr2, i) ? (jwstring(i, focknbr1) * jwstring(i, focknbr2)) : 1
+    _bit(focknbr2, i) ? (jwstring_left(i, focknbr1) * jwstring_left(i, focknbr2)) : 1
 end
 
 """

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -3,7 +3,9 @@
     
 Count the number of fermions to the right of site.
 """
-jwstring(site, focknbr) = iseven(count_ones(focknbr >> site)) ? 1 : -1
+jwstring(site, focknbr) = jwstring_right(site, focknbr)
+jwstring_right(site, focknbr) = iseven(count_ones(focknbr >> site)) ? 1 : -1
+jwstring_left(site, focknbr) = iseven(count_ones(focknbr) - count_ones(focknbr >> (site - 1))) ? 1 : -1
 
 
 """
@@ -15,7 +17,7 @@ function removefermion(digitposition, statefocknbr)
     cdag = focknbr_from_site_index(digitposition)
     newfocknbr = cdag ⊻ statefocknbr
     allowed = !iszero(cdag & statefocknbr)
-    fermionstatistics = jwstring(digitposition, statefocknbr)
+    fermionstatistics = jwstring_right(digitposition, statefocknbr)
     return allowed * newfocknbr, allowed * fermionstatistics
 end
 

--- a/src/wedge.jl
+++ b/src/wedge.jl
@@ -114,7 +114,7 @@ function phase_map(fockstates::AbstractVector, M::Int)
 end
 phase_map(N::Int) = phase_map(0:2^N-1, N)
 LazyPhaseMap(N::Int) = LazyPhaseMap{N}(0:2^N-1)
-
+SparseArrays.HigherOrderFns.is_supported_sparse_broadcast(::LazyPhaseMap, rest...) = SparseArrays.HigherOrderFns.is_supported_sparse_broadcast(rest...)
 (p::PhaseMap)(op::AbstractMatrix) = p.phases .* op
 (p::LazyPhaseMap)(op::AbstractMatrix) = p .* op
 @testitem "phasemap" begin
@@ -128,6 +128,8 @@ LazyPhaseMap(N::Int) = LazyPhaseMap{N}(0:2^N-1)
 
     for N in ns
         c = FermionBasis(1:N)
+        q = QubitBasis(1:N)
+        @test all(map((c, q) -> q == phis[N](c), c, q))
         c2 = map(c -> phis[N](c), c)
         @test phis[N](phis[N](c[1])) == c[1]
         # c is fermionic

--- a/src/wedge.jl
+++ b/src/wedge.jl
@@ -11,6 +11,7 @@ function wedge(b1::FermionBasis, b2::FermionBasis)
     qn = promote_symmetry(b1.symmetry, b2.symmetry)
     FermionBasis(newlabels; qn)
 end
+wedge(b1::FermionBasis, bs...) = foldl(wedge, bs, init=b1)
 
 promote_symmetry(s1::AbelianFockSymmetry{<:Any,<:Any,<:Any,F}, s2::AbelianFockSymmetry{<:Any,<:Any,<:Any,F}) where {F} = s1.conserved_quantity
 promote_symmetry(::AbelianFockSymmetry{<:Any,<:Any,<:Any,F1}, ::AbelianFockSymmetry{<:Any,<:Any,<:Any,F2}) where {F1,F2} = NoSymmetry()
@@ -29,57 +30,125 @@ end
 
 #TODO: specialize for ::NoSymmetry, where kron and parity operator can be used
 #TODO: Try first permuting, then kron, then permuting back
-"""
-    wedge(v1::AbstractVector{T1}, b1::FermionBasis{M1}, v2::AbstractVector{T2}, b2::FermionBasis{M2}, b3::FermionBasis=wedge(b1, b2)) where {M1,M2,T1,T2}
+# """
+#     wedge(v1::AbstractVector{T1}, b1::FermionBasis{M1}, v2::AbstractVector{T2}, b2::FermionBasis{M2}, b3::FermionBasis=wedge(b1, b2)) where {M1,M2,T1,T2}
 
-Compute the wedge product of two vectors `v1` and `v2` in the fermion basis `b1` and `b2`, respectively. Return a vector in the fermion basis `b3`.
+# Compute the wedge product of two vectors `v1` and `v2` in the fermion basis `b1` and `b2`, respectively. Return a vector in the fermion basis `b3`.
 
-# Arguments
-- `v1::AbstractVector`: The first vector.
-- `b1::FermionBasis`: The fermion basis for `v1`.
-- `v2::AbstractVector`: The second vector.
-- `b2::FermionBasis`: The fermion basis for `v2`.
-- `b3::FermionBasis`: The fermion basis for the resulting vector. Defaults to the wedge product of `b1` and `b2`.
+# # Arguments
+# - `v1::AbstractVector`: The first vector.
+# - `b1::FermionBasis`: The fermion basis for `v1`.
+# - `v2::AbstractVector`: The second vector.
+# - `b2::FermionBasis`: The fermion basis for `v2`.
+# - `b3::FermionBasis`: The fermion basis for the resulting vector. Defaults to the wedge product of `b1` and `b2`.
+# """
+# function wedge(v1::AbstractVector{T1}, b1::FermionBasis{M1}, v2::AbstractVector{T2}, b2::FermionBasis{M2}, b3::FermionBasis=wedge(b1, b2)) where {M1,M2,T1,T2}
+#     M3 = length(b3)
+#     check_wedge_basis_compatibility(b1, b2, b3)
+#     T3 = promote_type(T1, T2)
+#     v3 = zeros(T3, 2^M3)
+#     for f1 in 0:2^M1-1, f2 in 0:2^M2-1
+#         f3 = f1 + f2 * 2^M1
+#         pf = parity(f2)
+#         v3[focktoind(f3, b3)] += v1[focktoind(f1, b1)] * v2[focktoind(f2, b2)] * pf
+#     end
+#     return v3
+# end
+
+
+
+get_fockstates(::FermionBasis{M,<:Any,NoSymmetry}) where {M} = 0:2^M-1
+get_fockstates(b::FermionBasis) = get_fockstates(b.symmetry)
+get_fockstates(sym::AbelianFockSymmetry) = sym.indtofockdict
 """
-function wedge(v1::AbstractVector{T1}, b1::FermionBasis{M1}, v2::AbstractVector{T2}, b2::FermionBasis{M2}, b3::FermionBasis=wedge(b1, b2)) where {M1,M2,T1,T2}
-    M3 = length(b3)
-    check_wedge_basis_compatibility(b1, b2, b3)
-    T3 = promote_type(T1, T2)
-    v3 = zeros(T3, 2^M3)
-    for f1 in 0:2^M1-1, f2 in 0:2^M2-1
-        f3 = f1 + f2 * 2^M1
-        pf = parity(f2)
-        v3[focktoind(f3, b3)] += v1[focktoind(f1, b1)] * v2[focktoind(f2, b2)] * pf
+    wedge(ms::AbstractVector, bs::AbstractVector{<:FermionBasis}, b::FermionBasis=wedge(bs...))
+
+Compute the wedge product of matrices or vectors in `ms` with respect to the fermion bases `bs`, respectively. Return a matrix in the fermion basis `b`, which defaults to the wedge product of `bs`.
+"""
+function wedge(ms::AbstractVector, bs::AbstractVector{<:FermionBasis}, b::FermionBasis=wedge(bs...))
+    T = promote_type(map(eltype, ms)...)
+    dimlengths = map(length ∘ get_fockstates, bs)
+    Nout = prod(dimlengths)
+    if ndims(first(ms)) == 1
+        mout = zeros(T, Nout)
+        return wedge_vec!(mout, ms, bs, b, Val(length(ms)))
+    elseif ndims(first(ms)) == 2
+        mout = zeros(T, Nout, Nout)
+        return wedge_mat!(mout, ms, bs, b, Val(length(ms)))
     end
-    return v3
+    throw(ArgumentError("Only 1D or 2D arrays are supported"))
 end
-"""
-    wedge(m1::AbstractMatrix{T1}, b1::FermionBasis{M1}, m2::AbstractMatrix{T2}, b2::FermionBasis{M2}, b3::FermionBasis=wedge(b1, b2)) where {M1,M2,T1,T2}
-
-Compute the wedge product of two matrices `m1` and `m2` with respect to the fermion bases `b1` and `b2`, respectively. Return a matrix in the fermion basis `b3`, which defaults to the wedge product of `b1` and `b2`.
-
-# Arguments
-- `m1::Union{AbstractMatrix{T1}, UniformScaling{T1}}`: The first matrix.
-- `b1::FermionBasis{M1}`: The fermion basis associated with `m1`.
-- `m2::Union{AbstractMatrix{T2}, UniformScaling{T2}}`: The second matrix.
-- `b2::FermionBasis{M2}`: The fermion basis associated with `m2`.
-- `b3::FermionBasis`: The fermion basis associated with the resulting matrix. (optional)
-"""
-function wedge(m1::Union{AbstractMatrix{T1},UniformScaling{T1}}, b1::FermionBasis{M1}, m2::Union{AbstractMatrix{T2},UniformScaling{T2}}, b2::FermionBasis{M2}, b3::FermionBasis=wedge(b1, b2)) where {M1,M2,T1,T2}
-    M3 = length(b3)
-    check_wedge_basis_compatibility(b1, b2, b3)
-    T3 = promote_type(T1, T2)
-    m3 = zeros(T3, 2^M3, 2^M3)
-    for f1_1 in 0:2^M1-1, f1_2 in 0:2^M2-1
-        f1_3 = f1_1 + f1_2 * 2^M1
-        pf1 = parity(f1_2)
-        for f2_1 in 0:2^M1-1, f2_2 in 0:2^M2-1
-            f2_3 = f2_1 + f2_2 * 2^M1
-            pf2 = parity(f2_2)
-            m3[focktoind(f1_3, b3), focktoind(f2_3, b3)] += m1[focktoind(f1_1, b1), focktoind(f2_1, b1)] * m2[focktoind(f1_2, b2), focktoind(f2_2, b2)] * pf1 * pf2
+function wedge_mat!(mout, ms::AbstractVector, bs::AbstractVector{<:FermionBasis}, b::FermionBasis, ::Val{N}) where {N}
+    Ms = map(nbr_of_fermions, bs)
+    Mout = sum(Ms)
+    shifts = pushfirst!(cumsum(Ms), 0)
+    dimlengths = map(length ∘ get_fockstates, bs)
+    inds::CartesianIndices{N,NTuple{N,Base.OneTo{Int64}}} = CartesianIndices(Tuple(dimlengths))
+    for I in inds
+        TI = Tuple(I)
+        fock1 = map(indtofock, TI, bs)
+        fullfock = mapreduce((M, f) -> 2^M * f, +, shifts, fock1)
+        outind = focktoind(fullfock, b)
+        for I2 in inds
+            TI2 = Tuple(I2)
+            fock2 = map(indtofock, TI2, bs)
+            fullfock2 = mapreduce((M, f) -> 2^M * f, +, shifts, fock2)
+            v = mapreduce((m, b, i1, f1, i2, f2, M) -> m[i1, i2] * phase_factor(f1, f2, M), *, ms, bs, TI, fock1, TI2, fock2, Ms)
+            mout[outind, focktoind(fullfock2, b)] += v * phase_factor(fullfock, fullfock2, Mout)
         end
     end
-    return m3
+    return mout
+end
+function wedge_vec!(mout, ms::AbstractVector, bs::AbstractVector{<:FermionBasis}, b::FermionBasis, ::Val{N}) where {N}
+    Ms = map(nbr_of_fermions, bs)
+    partition = map(_b -> siteindices(collect(keys(_b)), b), bs)
+    U = embedding_unitary(partition, get_fockstates(b))
+    Mout = sum(Ms)
+    @assert length(unique(reduce(vcat, partition))) == Mout
+    shifts = pushfirst!(cumsum(Ms), 0)
+    dimlengths = map(length ∘ get_fockstates, bs)
+    inds::CartesianIndices{N,NTuple{N,Base.OneTo{Int64}}} = CartesianIndices(Tuple(dimlengths))
+    for I in inds
+        TI = Tuple(I)
+        fock1 = map(indtofock, TI, bs)
+        fullfock = mapreduce((M, f) -> 2^M * f, +, shifts, fock1)
+        outind = focktoind(fullfock, b)
+        mout[outind] += mapreduce((i1, m) -> m[i1], *, TI, ms)
+    end
+    return U * mout
+end
+
+# function partition_phase_factor(f, ξ)
+#     phase = 1
+#     for (s, Xs) in enumerate(ξ)
+#         mask = focknbr_from_site_indices(Xs)
+#         masked_f = mask & f
+#         for (r, Xr) in Iterators.drop(enumerate(ξ), s)
+#             for i in Xr
+#                 phase *= (_bit(f, i) ? jwstring_left(i, masked_f) : 1)
+#             end
+#         end
+#     end
+#     return phase
+# end
+function embedding_unitary(ξ, fockstates)
+    #for locally physical algebra, ie only for even operators or states of well-defined parity
+    #if ξ is ordered, the phases are +1. 
+    # Note that the jordan wigner modes are ordered in reverse
+    phases = ones(Int, length(fockstates))
+    for (s, Xs) in enumerate(ξ)
+        mask = focknbr_from_site_indices(Xs)
+        for (r, Xr) in Iterators.drop(enumerate(ξ), s)
+            for i in Xr
+                for (n, f) in zip(eachindex(phases), fockstates)
+                    if _bit(f, i)
+                        phases[n] *= jwstring_right(i, mask & f)
+                    end
+                end
+            end
+        end
+    end
+    return Diagonal(phases)
 end
 
 struct PhaseMap

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,7 +146,7 @@ end
     t2 = [i1 + 2i2 + 4i3 for i1 in (0, 1), i2 in (0, 1), i3 in (0, 1)]
     @test t1 == t2
 
-    @test sort(QuantumDots.svd(v, (1,), a).S .^ 2) ≈ eigvals(QuantumDots.partial_trace(v, (1,), a))
+    #@test sort(QuantumDots.svd(v, (1,), a).S .^ 2) ≈ eigvals(QuantumDots.partial_trace(v, (1,), a))
 
     c = FermionBasis(1:2, (:a, :b))
     cparity = FermionBasis(1:2, (:a, :b); qn=QuantumDots.parity)
@@ -218,6 +218,29 @@ end
     @test reduced_density_matrix13 ≈ many_body_density_matrix(G13, c12)
     @test reduced_density_matrix3 ≈ many_body_density_matrix(G3, c)
 
+end
+
+@testitem "Fermionic partial trace" begin
+    using LinearAlgebra
+    qns = [NoSymmetry(), ParityConservation(), FermionConservation()]
+    for qn in qns
+        c = FermionBasis(1:3; qn)
+        c1 = FermionBasis(1:1; qn)
+        c2 = FermionBasis(2:2; qn)
+        c12 = FermionBasis(1:2; qn)
+        c13 = FermionBasis(1:3; qn)
+        c23 = FermionBasis(2:3; qn)
+        γ = Hermitian([0I rand(ComplexF64, 4, 4); rand(ComplexF64, 4, 4) 0I])
+        f = c[1]
+        @test tr(c1[1] * partial_trace(γ, c1, c)) ≈ tr(f * γ)
+        @test tr(c12[1] * partial_trace(γ, c12, c)) ≈ tr(f * γ)
+        @test tr(c13[1] * partial_trace(γ, c13, c)) ≈ tr(f * γ)
+
+        f = c[2]
+        @test tr(c2[2] * partial_trace(γ, c2, c)) ≈ tr(f * γ)
+        @test tr(c12[2] * partial_trace(γ, c12, c)) ≈ tr(f * γ)
+        @test tr(c23[2] * partial_trace(γ, c23, c)) ≈ tr(f * γ)
+    end
 end
 
 @testitem "Wedge" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -223,8 +223,14 @@ end
 @testitem "Fermionic trace" begin
     using LinearAlgebra
     N = 4
-    c = FermionBasis(1:3)
-
+    cs = [FermionBasis(n:n) for n in 1:N]
+    c = FermionBasis(1:4)
+    ops = [rand(ComplexF64, 2, 2) for _ in 1:N]
+    op = wedge(ops, cs, c)
+    @test tr(op) ≈ prod(tr, ops)
+    
+    op = wedge(ops, cs[[3, 2, 1, 4]], c)
+    @test tr(op) ≈ prod(tr, ops)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -220,6 +220,14 @@ end
 
 end
 
+@testitem "Fermionic trace" begin
+    using LinearAlgebra
+    N = 4
+    c = FermionBasis(1:3)
+
+end
+
+
 @testitem "Fermionic partial trace" begin
     using LinearAlgebra
     qns = [NoSymmetry(), ParityConservation(), FermionConservation()]
@@ -247,7 +255,7 @@ end
     using Random, LinearAlgebra
     Random.seed!(1234)
 
-    for qn in [QuantumDots.NoSymmetry(), QuantumDots.parity, QuantumDots.fermionnumber]
+    for qn in [NoSymmetry(), ParityConservation(), FermionConservation()]
         b1 = FermionBasis(1:1; qn)
         b2 = FermionBasis(1:3; qn)
         @test_throws ArgumentError wedge(b1, b2)
@@ -255,63 +263,40 @@ end
         b3 = FermionBasis(1:3; qn)
         b3w = wedge(b1, b2)
         @test norm(b3w .- b3) == 0
-
-        for i1 in [[], [1]], i2 in [[], [1], [2], [1, 2]]
-            f1 = QuantumDots.focknbr_from_site_indices(i1)
-            f2 = QuantumDots.focknbr_from_site_indices(i2)
-            f3 = QuantumDots.focknbr_from_site_indices([i1..., 1 .+ i2...])
-
-            v1 = zeros(size(first(b1), 1))
-            v1[QuantumDots.focktoind(f1, b1)] = 1
-            v2 = zeros(size(first(b2), 1))
-            v2[QuantumDots.focktoind(f2, b2)] = 1
-            v3 = zeros(size(first(b3), 1))
-            v3[QuantumDots.focktoind(f3, b3)] = isodd(length(i2)) ? -1 : 1
-            @test wedge(v1, b1, v2, b2) ≈ v3
-        end
+        bs = [b1, b2]
 
         O1 = isodd.(QuantumDots.numberoperator(b1))
         O2 = isodd.(QuantumDots.numberoperator(b2))
         for P1 in [O1, I - O1], P2 in [O2, I - O2] #Loop over different parity sectors because of superselection. Otherwise, minus signs come into play
             v1 = P1 * rand(2)
             v2 = P2 * rand(4)
-            v3 = wedge(v1, b1, v2, b2)
+            v3 = wedge([v1, v2], bs)
             for k1 in keys(b1), k2 in keys(b2)
                 b1f = b1[k1]
                 b2f = b2[k2]
                 b3f = b3[k1] * b3[k2]
-                v3w = wedge(b1f * v1, b1, b2f * v2, b2, b3)
+                v3w = wedge([b1f * v1, b2f * v2], bs, b3)
                 v3f = b3f * v3
                 @test v3f == v3w || v3f == -v3w #Vectors are the same up to a sign
             end
         end
 
-        # The wedge product is a permutation of kron and a parity operator
-        v1 = rand(2)
-        v2 = rand(4)
-        v3 = wedge(v1, b1, v2, b2)
-        if b1.symmetry == QuantumDots.NoSymmetry()
-            @test kron(QuantumDots.parityoperator(b2) * v2, v1) == v3
-        end
-        @test sort(kron(QuantumDots.parityoperator(b2) * v2, v1), by=abs) == sort(v3, by=abs)
-
-
         # Test wedge of matrices
         P1 = QuantumDots.parityoperator(b1)
         P2 = QuantumDots.parityoperator(b2)
         P3 = QuantumDots.parityoperator(b3)
-        wedge(P1, b1, P2, b2, b3) ≈ P3
+        wedge([P1, P2], bs, b3) ≈ P3
 
 
         rho1 = rand(2, 2)
         rho2 = rand(4, 4)
-        rho3 = wedge(rho1, b1, rho2, b2, b3)
+        rho3 = wedge([rho1, rho2], bs, b3)
         for P1 in [P1 + I, I - P1], P2 in [P2 + I, I - P2] #Loop over different parity sectors because of superselection. Otherwise, minus signs come into play
             m1 = P1 * rho1 * P1
             m2 = P2 * rho2 * P2
-            P3 = wedge(P1, b1, P2, b2, b3)
+            P3 = wedge([P1, P2], bs, b3)
             m3 = P3 * rho3 * P3
-            @test wedge(m1, b1, m2, b2, b3) == m3
+            @test wedge([m1, m2], bs, b3) == m3
         end
 
         H1 = Matrix(0.5b1[1]' * b1[1])
@@ -322,15 +307,15 @@ end
         vals3, vecs3 = eigen(H3)
 
         # test wedging with I (UniformScaling)
-        H3w = wedge(H1, b1, I, b2, b3) + wedge(I, b1, H2, b2, b3)
+        H3w = wedge([H1, I], bs, b3) + wedge([I, H2], bs, b3)
         @test H3w == H3
-        @test wedge(I, b1, I, b2, b3) == one(H3)
+        @test wedge([I, I], bs, b3) == one(H3)
 
         vals3w = map(sum, Base.product(vals1, vals2)) |> vec
         p = sortperm(vals3w)
         vals3w[p] ≈ vals3
 
-        vecs3w = vec(map(v12 -> wedge(v12[1], b1, v12[2], b2, b3), Base.product(eachcol(vecs1), eachcol(vecs2))))[p]
+        vecs3w = vec(map(v12 -> wedge([v12[1], v12[2]], bs, b3), Base.product(eachcol(vecs1), eachcol(vecs2))))[p]
         @test all(map((v3, v3w) -> abs(dot(v3, v3w)) ≈ norm(v3) * norm(v3w), eachcol(vecs3), vecs3w))
 
         β = 0.7
@@ -340,19 +325,20 @@ end
         rmul!(rho2, 1 / tr(rho2))
         rho3 = exp(-β * H3)
         rmul!(rho3, 1 / tr(rho3))
-        rho3w = wedge(rho1, b1, rho2, b2, b3)
+        rho3w = wedge([rho1, rho2], bs, b3)
         @test rho3w ≈ rho3
-
-        @test partial_trace(wedge(rho1, b1, rho2, b2, b3), b1, b3) ≈ rho1
-        @test partial_trace(wedge(rho1, b1, rho2, b2, b3), b2, b3) ≈ rho2
-        @test wedge(blockdiagonal(rho1, b1), b1, blockdiagonal(rho2, b2), b2, b3) ≈ wedge(blockdiagonal(rho1, b1), b1, rho2, b2, b3)
-        @test wedge(blockdiagonal(rho1, b1), b1, blockdiagonal(rho2, b2), b2, b3) ≈ wedge(rho1, b1, rho2, b2, b3)
+        bs = [b1, b2]
+        @test partial_trace(wedge([rho1, rho2], bs, b3), b1, b3) ≈ rho1
+        @test partial_trace(wedge([rho1, rho2], bs, b3), b2, b3) ≈ rho2
+        @test wedge([blockdiagonal(rho1, b1), blockdiagonal(rho2, b2)], bs, b3) ≈ wedge([blockdiagonal(rho1, b1), rho2], bs, b3)
+        @test wedge([blockdiagonal(rho1, b1), blockdiagonal(rho2, b2)], bs, b3) ≈ wedge([rho1, rho2], bs, b3)
 
         # Test BD1_hamiltonian
         b1 = FermionBasis(1:2, (:↑, :↓); qn)
         b2 = FermionBasis(3:4, (:↑, :↓); qn)
         b12 = FermionBasis(1:4, (:↑, :↓); qn)
         b12w = wedge(b1, b2)
+        bs = [b1, b2]
         θ1 = 0.5
         θ2 = 0.2
         params1 = (; μ=1, t=0.5, Δ=2.0, V=0, θ=parameter(θ1, :diff), ϕ=1.0, h=4.0, U=2.0, Δ1=0.1)
@@ -361,10 +347,10 @@ end
         H1 = QuantumDots.BD1_hamiltonian(b1; params1...)
         H2 = QuantumDots.BD1_hamiltonian(b2; params2...)
 
-        H12w = wedge(H1, b1, I, b2, b12w) + wedge(I, b1, H2, b2, b12w)
+        H12w = wedge([H1, I], bs, b12w) + wedge([I, H2], bs, b12w)
         H12 = Matrix(QuantumDots.BD1_hamiltonian(b12; params12...))
 
-        v12w = wedge(eigvecs(Matrix(H1))[:, 1], b1, eigvecs(Matrix(H2))[:, 1], b2, b12w)
+        v12w = wedge([eigvecs(Matrix(H1))[:, 1], eigvecs(Matrix(H2))[:, 1]], bs, b12w)
         v12 = eigvecs(H12)[:, 1]
         v12ww = eigvecs(H12w)[:, 1]
         sort(abs.(v12w)) - sort(abs.(v12))
@@ -377,9 +363,6 @@ end
     b1 = FermionBasis(1:2; qn=QuantumDots.parity)
     b2 = FermionBasis(2:4; qn=QuantumDots.parity)
     @test_throws ArgumentError wedge(b1, b2)
-    b2 = FermionBasis(3:4; qn=QuantumDots.parity)
-    b3 = FermionBasis([1, 3, 2, 4]; qn=QuantumDots.parity)
-    @test_throws ArgumentError wedge(rand(4, 4), b1, rand(4, 4), b2, b3)
 end
 
 @testitem "QubitBasis" begin


### PR DESCRIPTION
Fixes a bug in the ordering of a jordan wigner string. wedge product should now work for any number of products. More tests of its properties would be nice.