### PR TITLE
conversions between symbolic fermions and majoranas

### DIFF
--- a/ext/QuantumDotsSymbolicsExt.jl
+++ b/ext/QuantumDotsSymbolicsExt.jl
@@ -78,6 +78,7 @@ function TSL_generator(qn=NoSymmetry(); blocks=qn !== NoSymmetry(), dense=false,
 end
 
 function fermion_to_majorana(f::SymbolicFermionBasis, a::SymbolicMajoranaBasis, b::SymbolicMajoranaBasis)
+    a.universe == b.universe || throw(ArgumentError("Majorana bases must anticommute"))
     sgn(x) = x.creation ? 1 : -1 # what convention to use? or should the user specify?
     is_fermion_in_basis(x, basis) = x isa QuantumDots.FermionSym && x.basis == basis
     rw = @rule ~x::(x -> is_fermion_in_basis(x, f)) => 1/2 * (a[(~x).label] + sgn(~x) * 1im * b[(~x).label])
@@ -85,6 +86,7 @@ function fermion_to_majorana(f::SymbolicFermionBasis, a::SymbolicMajoranaBasis, 
 end
 
 function majorana_to_fermion(a::SymbolicMajoranaBasis, b::SymbolicMajoranaBasis, f::SymbolicFermionBasis)
+    a.universe == b.universe || throw(ArgumentError("Majorana bases must anticommute"))
     is_majorana_in_basis(x, basis) = x isa QuantumDots.MajoranaSym && x.basis == basis
     rw1 = @rule ~x::(x -> is_majorana_in_basis(x, a)) => f[(~x).label] + f[(~x).label]'
     rw2 = @rule ~x::(x -> is_majorana_in_basis(x, b)) => 1im * (f[(~x).label] - f[(~x).label]')

--- a/ext/QuantumDotsSymbolicsExt.jl
+++ b/ext/QuantumDotsSymbolicsExt.jl
@@ -3,7 +3,7 @@ module QuantumDotsSymbolicsExt
 using QuantumDots, Symbolics
 using QuantumDots.BlockDiagonals
 import QuantumDots: fastgenerator, fastblockdiagonal, TSL_generator,
-    NoSymmetry, TSL_hamiltonian, FermionBdGBasis, fermion2majorana,
+    NoSymmetry, TSL_hamiltonian, FermionBdGBasis, fermion2majorana, majorana2fermion,
     SymbolicMajoranaBasis, SymbolicFermionBasis
 
 function fastgenerator(gen, N)

--- a/ext/QuantumDotsSymbolicsExt.jl
+++ b/ext/QuantumDotsSymbolicsExt.jl
@@ -3,7 +3,7 @@ module QuantumDotsSymbolicsExt
 using QuantumDots, Symbolics
 using QuantumDots.BlockDiagonals
 import QuantumDots: fastgenerator, fastblockdiagonal, TSL_generator,
-    NoSymmetry, TSL_hamiltonian, FermionBdGBasis, fermion2majorana, majorana2fermion,
+    NoSymmetry, TSL_hamiltonian, FermionBdGBasis, fermion_to_majorana, majorana_to_fermion,
     SymbolicMajoranaBasis, SymbolicFermionBasis
 
 function fastgenerator(gen, N)
@@ -77,17 +77,17 @@ function TSL_generator(qn=NoSymmetry(); blocks=qn !== NoSymmetry(), dense=false,
     return tsl, tsl!, m, c
 end
 
-function fermion2majorana(f::SymbolicFermionBasis, γ::SymbolicMajoranaBasis, γ̃::SymbolicMajoranaBasis)
+function fermion_to_majorana(f::SymbolicFermionBasis, a::SymbolicMajoranaBasis, b::SymbolicMajoranaBasis)
     sgn(x) = x.creation ? 1 : -1 # what convention to use? or should the user specify?
     is_fermion_in_basis(x, basis) = x isa QuantumDots.FermionSym && x.basis == basis
-    rw = @rule ~x::(x -> is_fermion_in_basis(x, f)) => 1/2 * (γ[(~x).label] + sgn(~x) * 1im * γ̃[(~x).label])
+    rw = @rule ~x::(x -> is_fermion_in_basis(x, f)) => 1/2 * (a[(~x).label] + sgn(~x) * 1im * b[(~x).label])
     return Rewriters.Prewalk(Rewriters.PassThrough(rw))
 end
 
-function majorana2fermion(γ::SymbolicMajoranaBasis, γ̃::SymbolicMajoranaBasis, f::SymbolicFermionBasis)
+function majorana_to_fermion(a::SymbolicMajoranaBasis, b::SymbolicMajoranaBasis, f::SymbolicFermionBasis)
     is_majorana_in_basis(x, basis) = x isa QuantumDots.MajoranaSym && x.basis == basis
-    rw1 = @rule ~x::(x -> is_majorana_in_basis(x, γ)) => f[(~x).label] + f[(~x).label]'
-    rw2 = @rule ~x::(x -> is_majorana_in_basis(x, γ̃)) => 1im * (f[(~x).label] - f[(~x).label]')
+    rw1 = @rule ~x::(x -> is_majorana_in_basis(x, a)) => f[(~x).label] + f[(~x).label]'
+    rw2 = @rule ~x::(x -> is_majorana_in_basis(x, b)) => 1im * (f[(~x).label] - f[(~x).label]')
     return Rewriters.Prewalk(Rewriters.Chain([rw1, rw2]))
 end
 

--- a/ext/QuantumDotsSymbolicsExt.jl
+++ b/ext/QuantumDotsSymbolicsExt.jl
@@ -81,7 +81,7 @@ function fermion_to_majorana(f::SymbolicFermionBasis, a::SymbolicMajoranaBasis, 
     a.universe == b.universe || throw(ArgumentError("Majorana bases must anticommute"))
     sgn(x) = x.creation ? 1 : -1 # what convention to use? or should the user specify?
     is_fermion_in_basis(x, basis) = x isa QuantumDots.FermionSym && x.basis == basis
-    rw = @rule ~x::(x -> is_fermion_in_basis(x, f)) => 1/2 * (a[(~x).label] + sgn(~x) * 1im * b[(~x).label])
+    rw = @rule ~x::(x -> is_fermion_in_basis(x, f)) => 1 / 2 * (a[(~x).label] + sgn(~x) * 1im * b[(~x).label])
     return Rewriters.Prewalk(Rewriters.PassThrough(rw))
 end
 

--- a/src/QuantumDots.jl
+++ b/src/QuantumDots.jl
@@ -25,8 +25,8 @@ export FermionConservation, NoSymmetry, ParityConservation, IndexConservation
 function fastgenerator end
 function fastblockdiagonal end
 function TSL_generator end
-function fermion2majorana end
-function majorana2fermion end
+function fermion_to_majorana end
+function majorana_to_fermion end
 
 include("structs.jl")
 include("fock.jl")

--- a/src/QuantumDots.jl
+++ b/src/QuantumDots.jl
@@ -25,6 +25,8 @@ export FermionConservation, NoSymmetry, ParityConservation, IndexConservation
 function fastgenerator end
 function fastblockdiagonal end
 function TSL_generator end
+function fermion2majorana end
+function majorana2fermion end
 
 include("structs.jl")
 include("fock.jl")

--- a/src/symbolics/symbolic_majoranas.jl
+++ b/src/symbolics/symbolic_majoranas.jl
@@ -147,18 +147,18 @@ TermInterface.children(a::MajoranaSym) = arguments(a)
 end
 
 @testitem "Rewrite rules" begin
-    import QuantumDots: fermion2majorana, majorana2fermion
+    import QuantumDots: fermion_to_majorana, majorana_to_fermion
     using Symbolics
     @majoranas a b
     @fermions f
-    f2m = fermion2majorana(f, a, b)
-    m2f = majorana2fermion(a, b, f)
-    @test f2m(f[1]) == 1/2 * (a[1] - 1im * b[1])
-    @test f2m(f[1]') == 1/2 * (a[1] + 1im * b[1])
-    @test f2m(f[1]'*f[1]) == 1/2 * (1 + 1im*b[1]*a[1])
-    @test m2f(a[1]) == f[1] + f[1]'
-    @test m2f(b[1]) == 1im * (f[1] - f[1]')
-    @test m2f(1im*b[1]*a[1]) == 2*f[1]'*f[1] - 1
+    to_maj = fermion_to_majorana(f, a, b)
+    to_ferm = majorana_to_fermion(a, b, f)
+    @test to_maj(f[1]) == 1/2 * (a[1] - 1im * b[1])
+    @test to_maj(f[1]') == 1/2 * (a[1] + 1im * b[1])
+    @test to_maj(f[1]'*f[1]) == 1/2 * (1 + 1im*b[1]*a[1])
+    @test to_ferm(a[1]) == f[1] + f[1]'
+    @test to_ferm(b[1]) == 1im * (f[1] - f[1]')
+    @test to_ferm(1im*b[1]*a[1]) == 2*f[1]'*f[1] - 1
     expr = 10*f[1]'*f[2] - f[1]*f[2] + f[1]'*f[2]'*f[3]
-    @test m2f(f2m(expr)) == expr
+    @test to_ferm(to_maj(expr)) == expr
 end

--- a/src/symbolics/symbolic_majoranas.jl
+++ b/src/symbolics/symbolic_majoranas.jl
@@ -136,14 +136,14 @@ TermInterface.children(a::MajoranaSym) = arguments(a)
     @test substitute(γ[1], 1 => 2) == γ[2]
     @test substitute(γ[:a] * γ[:b] + 1, :a => :b) == 2
 
-    r = (@rule ~x::(x -> x isa QuantumDots.AbstractFermionSym) => (~x).basis[min((~x).label+1,10)])
+    r = (@rule ~x::(x -> x isa QuantumDots.AbstractFermionSym) => (~x).basis[min((~x).label + 1, 10)])
     @test r(f[1]) == f[2]
     @test simplify(f[1], r) == f[10] # applies rule repeatedly until no change
     r2 = Rewriters.Prewalk(Rewriters.PassThrough(r)) # should work on composite expressions. Postwalk also works.
-    @test r2(2*f[2]) == 2f[3]
-    @test simplify(2f[1], r2) == 2f[10] 
-    @test r2(2*f[1]*f[2] + f[3]) == 2*f[2]*f[3] + f[4]
-    @test simplify(2*f[1]'*f[2] + f[3], r2) == 2*f[10]'*f[10] + f[10]
+    @test r2(2 * f[2]) == 2f[3]
+    @test simplify(2f[1], r2) == 2f[10]
+    @test r2(2 * f[1] * f[2] + f[3]) == 2 * f[2] * f[3] + f[4]
+    @test simplify(2 * f[1]' * f[2] + f[3], r2) == 2 * f[10]' * f[10] + f[10]
 end
 
 @testitem "Rewrite rules" begin
@@ -153,13 +153,13 @@ end
     @fermions f
     to_maj = fermion_to_majorana(f, a, b)
     to_ferm = majorana_to_fermion(a, b, f)
-    @test to_maj(f[1]) == 1/2 * (a[1] - 1im * b[1])
-    @test to_maj(f[1]') == 1/2 * (a[1] + 1im * b[1])
-    @test to_maj(f[1]'*f[1]) == 1/2 * (1 + 1im*b[1]*a[1])
+    @test to_maj(f[1]) == 1 / 2 * (a[1] - 1im * b[1])
+    @test to_maj(f[1]') == 1 / 2 * (a[1] + 1im * b[1])
+    @test to_maj(f[1]' * f[1]) == 1 / 2 * (1 + 1im * b[1] * a[1])
     @test to_ferm(a[1]) == f[1] + f[1]'
     @test to_ferm(b[1]) == 1im * (f[1] - f[1]')
-    @test to_ferm(1im*b[1]*a[1]) == 2*f[1]'*f[1] - 1
-    expr = 10*f[1]'*f[2] - f[1]*f[2] + f[1]'*f[2]'*f[3]
+    @test to_ferm(1im * b[1] * a[1]) == 2 * f[1]' * f[1] - 1
+    expr = 10 * f[1]' * f[2] - f[1] * f[2] + f[1]' * f[2]' * f[3]
     @test to_ferm(to_maj(expr)) == expr
     @test to_ferm(to_maj(expr)^2) == expr^2
     @test to_ferm(expr) == expr
@@ -167,5 +167,5 @@ end
     @fermions f2
     @majoranas a2 b2
     @test to_maj(f2[1]) == f2[1]
-    @test_throws ArgumentError fermion_to_majorana(f, a, b2) # 
+    @test_throws ArgumentError fermion_to_majorana(f, a, b2)
 end

--- a/src/symbolics/symbolic_majoranas.jl
+++ b/src/symbolics/symbolic_majoranas.jl
@@ -145,3 +145,20 @@ TermInterface.children(a::MajoranaSym) = arguments(a)
     @test r2(2*f[1]*f[2] + f[3]) == 2*f[2]*f[3] + f[4]
     @test simplify(2*f[1]'*f[2] + f[3], r2) == 2*f[10]'*f[10] + f[10]
 end
+
+@testitem "Rewrite rules" begin
+    import QuantumDots: fermion2majorana, majorana2fermion
+    using Symbolics
+    @majoranas a b
+    @fermions f
+    f2m = fermion2majorana(f, a, b)
+    m2f = majorana2fermion(a, b, f)
+    @test f2m(f[1]) == 1/2 * (a[1] - 1im * b[1])
+    @test f2m(f[1]') == 1/2 * (a[1] + 1im * b[1])
+    @test f2m(f[1]'*f[1]) == 1/2 * (1 + 1im*b[1]*a[1])
+    @test m2f(a[1]) == f[1] + f[1]'
+    @test m2f(b[1]) == 1im * (f[1] - f[1]')
+    @test m2f(1im*b[1]*a[1]) == 2*f[1]'*f[1] - 1
+    expr = 10*f[1]'*f[2] - f[1]*f[2] + f[1]'*f[2]'*f[3]
+    @test m2f(f2m(expr)) == expr
+end

--- a/src/symbolics/symbolic_majoranas.jl
+++ b/src/symbolics/symbolic_majoranas.jl
@@ -161,4 +161,11 @@ end
     @test to_ferm(1im*b[1]*a[1]) == 2*f[1]'*f[1] - 1
     expr = 10*f[1]'*f[2] - f[1]*f[2] + f[1]'*f[2]'*f[3]
     @test to_ferm(to_maj(expr)) == expr
+    @test to_ferm(to_maj(expr)^2) == expr^2
+    @test to_ferm(expr) == expr
+
+    @fermions f2
+    @majoranas a2 b2
+    @test to_maj(f2[1]) == f2[1]
+    @test_throws ArgumentError fermion_to_majorana(f, a, b2) # 
 end


### PR DESCRIPTION
Added the 2-Majorana species versions of the rules (#140). I put them in the extension since I needed `Symbolics`. Still need to add support for using single Majorana species.