### PR TITLE
add support for different majorana conventions

### DIFF
--- a/ext/QuantumDotsSymbolicsExt.jl
+++ b/ext/QuantumDotsSymbolicsExt.jl
@@ -77,19 +77,20 @@ function TSL_generator(qn=NoSymmetry(); blocks=qn !== NoSymmetry(), dense=false,
     return tsl, tsl!, m, c
 end
 
-function fermion_to_majorana(f::SymbolicFermionBasis, a::SymbolicMajoranaBasis, b::SymbolicMajoranaBasis)
+function fermion_to_majorana(f::SymbolicFermionBasis, a::SymbolicMajoranaBasis, b::SymbolicMajoranaBasis; leijnse_convention=true)
     a.universe == b.universe || throw(ArgumentError("Majorana bases must anticommute"))
-    sgn(x) = x.creation ? 1 : -1 # what convention to use? or should the user specify?
+    sgn(x) = leijnse_convention ? (x.creation ? -1 : 1) : (x.creation ? 1 : -1)
     is_fermion_in_basis(x, basis) = x isa QuantumDots.FermionSym && x.basis == basis
-    rw = @rule ~x::(x -> is_fermion_in_basis(x, f)) => 1 / 2 * (a[(~x).label] + sgn(~x) * 1im * b[(~x).label])
+    rw = @rule ~x::(x -> is_fermion_in_basis(x, f)) => 1 // 2 * (a[(~x).label] + sgn(~x) * 1im * b[(~x).label])
     return Rewriters.Prewalk(Rewriters.PassThrough(rw))
 end
 
-function majorana_to_fermion(a::SymbolicMajoranaBasis, b::SymbolicMajoranaBasis, f::SymbolicFermionBasis)
+function majorana_to_fermion(a::SymbolicMajoranaBasis, b::SymbolicMajoranaBasis, f::SymbolicFermionBasis; leijnse_convention=true)
     a.universe == b.universe || throw(ArgumentError("Majorana bases must anticommute"))
+    sgn = leijnse_convention ? 1 : -1
     is_majorana_in_basis(x, basis) = x isa QuantumDots.MajoranaSym && x.basis == basis
     rw1 = @rule ~x::(x -> is_majorana_in_basis(x, a)) => f[(~x).label] + f[(~x).label]'
-    rw2 = @rule ~x::(x -> is_majorana_in_basis(x, b)) => 1im * (f[(~x).label] - f[(~x).label]')
+    rw2 = @rule ~x::(x -> is_majorana_in_basis(x, b)) => sgn * 1im * (f[(~x).label]' - f[(~x).label])
     return Rewriters.Prewalk(Rewriters.Chain([rw1, rw2]))
 end
 


### PR DESCRIPTION
Added a way to change the Majorana convention. I used `M Leijnse, K Flensberg, Semiconductor Science and Technology 27 (12), 124003` as the default convention. (See #140)