### PR TITLE
Partial_transpose

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumDots"
 uuid = "312194fd-fec5-4b07-ba1c-a40d7013a56a"
 authors = ["Viktor Svensson, William Samuelson"]
-version = "0.14.1"
+version = "0.15.0"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/src/fock.jl
+++ b/src/fock.jl
@@ -100,12 +100,12 @@ end
 """
     partial_trace!(mout, m::AbstractMatrix, labels, b::FermionBasis, sym::AbstractSymmetry=NoSymmetry())
 
-Compute the partial trace of a matrix `m` in basis `b`, leaving only the subsystems specified by `labels`. The result is stored in `mout`, and `sym` determines the ordering of the basis states.
+Compute the fermionic partial trace of a matrix `m` in basis `b`, leaving only the subsystems specified by `labels`. The result is stored in `mout`, and `sym` determines the ordering of the basis states.
 """
 function partial_trace!(mout, m::AbstractMatrix{T}, labels, b::FermionBasis{M}, sym::AbstractSymmetry=NoSymmetry()) where {T,M}
     N = length(labels)
     fill!(mout, zero(eltype(mout)))
-    outinds = siteindices(labels, b) #::NTuple{N,Int}
+    outinds = siteindices(labels, b)  
     @assert all(outinds[n] > outinds[n-1] for n in Iterators.drop(eachindex(outinds), 1)) "Subsystems must be ordered in the same way as the full system" #Is this true?
     bitmask = 2^M - 1 - focknbr_from_site_indices(outinds)
     outbits(f) = map(i -> _bit(f, i), outinds)
@@ -124,15 +124,15 @@ function partial_trace!(mout, m::AbstractMatrix{T}, labels, b::FermionBasis{M}, 
 end
 
 """
-    partial_trace!(mout, m::AbstractMatrix, labels, b::FermionBasis, sym::AbstractSymmetry=NoSymmetry())
+    partial_transpose(m::AbstractMatrix, labels, b::FermionBasis{M})
 
-Compute the partial trace of a matrix `m` in basis `b`, leaving only the subsystems specified by `labels`. The result is stored in `mout`, and `sym` determines the ordering of the basis states.
+Compute the fermionic partial transpose of a matrix `m` in subsystem denoted by `labels`.
 """
-function partial_transpose(m::AbstractMatrix{T}, labels, b::FermionBasis{M}) where {T,M}
+function partial_transpose(m::AbstractMatrix, labels, b::FermionBasis)
     mout = zero(m)
     partial_transpose!(mout, m, labels, b)
 end
-function partial_transpose!(mout, m::AbstractMatrix{T}, labels, b::FermionBasis{M}) where {T,M}
+function partial_transpose!(mout, m::AbstractMatrix, labels, b::FermionBasis{M}) where {M}
     fill!(mout, zero(eltype(mout)))
     outinds = siteindices(labels, b)
     bitmask = 2^M - 1 - focknbr_from_site_indices(outinds)

--- a/src/fock.jl
+++ b/src/fock.jl
@@ -201,7 +201,7 @@ end
     @test !(Mpt ≈ transpose(M)) # partial transpose is not the same as transpose even if the full system is transposed
     @test M ≈ partial_transpose(M, (), cN)
 
-    M = rand(ComplexF64, 2^N, 2^N) 
+    M = rand(ComplexF64, 2^N, 2^N)
     pt(l, M) = partial_transpose(M, l, cN)
     for (i, j) in pair_iterator
         @test pt((i, j), M) ≈ pt((j, i), M) ≈ pt(j, pt(i, M)) ≈ pt(i, pt(j, M))
@@ -210,6 +210,8 @@ end
         @test pt((i, j, k), M) ≈ pt((j, i, k), M) ≈ pt((j, k, i), M) ≈ pt((k, j, i), M) ≈ pt((k, i, j), M) ≈ pt((i, k, j), M) ≈ pt(i, pt(j, pt(k, M))) ≈ pt(j, pt(i, pt(k, M))) ≈ pt(k, pt(j, pt(i, M)))
     end
 
+    @test pt((1, 2), M) ≈ pt((1, 2, 3, 4), pt((3, 4), M))
+    @test all(pt(l, pt(l, M)) == M for l in Iterators.flatten((single_subsystems, pair_iterator, triple_iterator)))
 end
 
 


### PR DESCRIPTION
Added fermionic partial transpose, which is similar to the standard partial transpose (https://en.wikipedia.org/wiki/Peres%E2%80%93Horodecki_criterion), but with the fermionic tensor product instead of the standard tensor product.