### PR TITLE
More wedge-related operations

### DIFF
--- a/src/wedge.jl
+++ b/src/wedge.jl
@@ -134,7 +134,7 @@ Compute the fermionic embedding of a matrix `m` in the basis `b` into the basis 
 """
 function fermionic_embedding(m, b, bnew)
     # See eq. 20 in J. Phys. A: Math. Theor. 54 (2021) 393001
-    bbar_labs = setdiff([keys(bnew)...], [keys(b)...]) # arrays to keep order
+    bbar_labs = setdiff(collect(keys(bnew)), collect(keys(b))) # arrays to keep order
     qn = promote_symmetry(b.symmetry, bnew.symmetry)
     bbar = FermionBasis(bbar_labs; qn)
     return wedge([m, I], [b, bbar], bnew)

--- a/src/wedge.jl
+++ b/src/wedge.jl
@@ -137,7 +137,7 @@ function fermionic_embedding(m, b, bnew)
     bbar_labs = setdiff(collect(keys(bnew)), collect(keys(b))) # arrays to keep order
     qn = promote_symmetry(b.symmetry, bnew.symmetry)
     bbar = FermionBasis(bbar_labs; qn)
-    return wedge([m, I], [b, bbar], bnew)
+    return wedge((m, I), (b, bbar), bnew)
 end
 
 """


### PR DESCRIPTION
I added `fermionic_embedding` and `ordered_prod_of_embeddings` according to eqs. 20 and 26 in `J. Phys. A: Math. Theor. 54 (2021) 393001` and some more of the tests in #134. 

However, I can't get eq. 95 to work. I guess there is a problem with `ordered_prod_of_embeddings`. I am slightly confused about the order of the product.

Also, note that I had to reverse the order of the product in the test for eq. 19.