### PR TITLE
Partial_trace

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumDots"
 uuid = "312194fd-fec5-4b07-ba1c-a40d7013a56a"
 authors = ["Viktor Svensson, William Samuelson"]
-version = "0.16.7"
+version = "0.17.0"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/src/QuantumDots.jl
+++ b/src/QuantumDots.jl
@@ -64,7 +64,7 @@ PrecompileTools.@compile_workload begin
     blockdiagonal(c2[1, :s], c2)
     c3 = FermionBasis(2:2; qn=FermionConservation())
     vals, vecs = eigen(Matrix(c1[1]' * c1[1]))
-    partial_trace(vecs[1, :], (1,), c1)
+    partial_trace(vecs[1, :], c1, FermionBasis(1:1))
     wedge(c1, c2)
     cbdg = FermionBdGBasis(1:1, (:s,))
     diagonalize(BdGMatrix(cbdg[1, :s]' * cbdg[1, :s]))

--- a/src/bdg.jl
+++ b/src/bdg.jl
@@ -45,7 +45,7 @@ Base.keys(b::FermionBdGBasis) = keys(b.position)
 Base.keys(qp::QuasiParticle) = keys(qp.weights)
 basis(qp::QuasiParticle) = qp.basis
 function _left_half_labels(basis::FermionBdGBasis)
-    N = nbr_of_fermions(basis)
+    N = nbr_of_modes(basis)
     collect(keys(basis))[1:Int(ceil(N / 2))]
 end
 function majorana_polarization(f::QuasiParticle, labels=_left_half_labels(basis(f)))

--- a/src/fock.jl
+++ b/src/fock.jl
@@ -499,8 +499,8 @@ function reshape_to_matrix(t::AbstractArray{<:Any,N}, leftindices::NTuple{NL,Int
     reshape(tperm, lsize, rsize)
 end
 
-function LinearAlgebra.svd(v::AbstractVector, leftlabels::NTuple, b::AbstractBasis)
-    linds = siteindices(leftlabels, b)
-    t = tensor(v, b)
-    svd(reshape_to_matrix(t, linds))
-end
+# function LinearAlgebra.svd(v::AbstractVector, leftlabels::NTuple, b::AbstractBasis)
+#     linds = siteindices(leftlabels, b)
+#     t = tensor(v, b)
+#     svd(reshape_to_matrix(t, linds))
+# end

--- a/src/fock.jl
+++ b/src/fock.jl
@@ -443,9 +443,9 @@ end
         m2 = rand(ComplexF64, d1 * d2, d1 * d2)
         t1 = reshape(m1, b, bs, false)
         t2 = reshape(m2, b, bs, false)
-        t3 = Array{ComplexF64}(undef, d1, d2, d1, d2)
-        for i in 1:d1, j in 1:d2, k in 1:d1, l in 1:d2
-            t3[i, j, k, l] += sum(t1[i, j, k1, k2] * t2[k1, k2, k, l] for k1 in 1:d1, k2 in 1:d2)
+        t3 = zeros(ComplexF64, d1, d2, d1, d2)
+        for i in 1:d1, j in 1:d2, k in 1:d1, l in 1:d2, k1 in 1:d1, k2 in 1:d2
+            t3[i, j, k, l] += t1[i, j, k1, k2] * t2[k1, k2, k, l]
         end
         @test reshape(m1 * m2, b, bs, false) ≈ t3
         @test m1 * m2 ≈ reshape(t3, bs, b, false)

--- a/src/fock.jl
+++ b/src/fock.jl
@@ -418,8 +418,8 @@ end
     for (qn1, qn2, qn3) in Base.product(qns, qns, qns)
         b1 = FermionBasis(1:2; qn=qn1)
         b2 = FermionBasis(3:3; qn=qn2)
-        d1 = 2^QuantumDots.nbr_of_fermions(b1)
-        d2 = 2^QuantumDots.nbr_of_fermions(b2)
+        d1 = 2^QuantumDots.nbr_of_modes(b1)
+        d2 = 2^QuantumDots.nbr_of_modes(b2)
         bs = (b1, b2)
         b = FermionBasis(vcat(keys(b1)..., keys(b2)...); qn=qn3)
         m = b[1]

--- a/src/fock.jl
+++ b/src/fock.jl
@@ -153,7 +153,7 @@ Compute the partial trace of a matrix `m`, leaving the subsystem defined by the 
 function partial_trace(m::AbstractMatrix{T}, b::AbstractBasis, bout::AbstractBasis, phase_factors=use_partial_trace_phase_factors(b, bout)) where {T}
     N = length(get_fockstates(bout))
     mout = zeros(T, N, N)
-    partial_trace!(mout, m, b, bout)
+    partial_trace!(mout, m, b, bout, phase_factors)
 end
 
 use_partial_trace_phase_factors(b1::FermionBasis, b2::FermionBasis) = true
@@ -465,12 +465,12 @@ end
         Hvirtual = rand(ComplexF64, length(basis1), length(basis2))
         H = sum(Hvirtual[I] * wedge((basis1[I[1]], basis2[I[2]]), bs, b) for I in CartesianIndices(Hvirtual))
         t = reshape(H, b, bs)
-        H2 = QuantumDots.reshape_to_matrix(t, (1, 3))
-        @test svdvals(Hvirtual) ≈ svdvals(H2)
+        Hvirtual2 = QuantumDots.reshape_to_matrix(t, (1, 3))
+        @test svdvals(Hvirtual) ≈ svdvals(Hvirtual2)
 
         ## Test consistency with partial trace
         m = rand(ComplexF64, d1 * d2, d1 * d2)
-        m2 = partial_trace(m, b2, b)
+        m2 = partial_trace(m, b, b2)
         t = reshape(m, b, bs, true)
         tpt = sum(t[k, :, k, :] for k in axes(t, 1))
         @test m2 ≈ tpt

--- a/src/hamiltonians.jl
+++ b/src/hamiltonians.jl
@@ -36,7 +36,7 @@ _kitaev_2site(f1, f2; t, Δ, V) = hopping(-t, f1, f2) + V * coulomb(f1, f2) + pa
 _kitaev_1site(f; μ) = -μ * numberop(f)
 
 function kitaev_hamiltonian(c::AbstractBasis; μ, t, Δ, V=0)
-    N = nbr_of_fermions(c)
+    N = nbr_of_modes(c)
     h1s = (_kitaev_1site(c[j]; μ=getvalue(μ, j, N)) for j in 1:N)
     h2s = (_kitaev_2site(c[j], c[mod1(j + 1, N)]; t=getvalue(t, j, N; size=2), Δ=getvalue(Δ, j, N; size=2), V=getvalue(V, j, N; size=2)) for j in 1:N)
     sum(h1s) + sum(h2s)
@@ -111,7 +111,7 @@ getvalue(v::Union{<:AbstractVector,<:Tuple}, i, N; size=1) = v[i]
 getvalue(x::Number, i, N; size=1) = 1 <= i <= N + 1 - size ? x : zero(x)
 
 function BD1_hamiltonian(c::AbstractBasis; μ, h, t, Δ, Δ1, U, V, θ, ϕ)
-    M = nbr_of_fermions(c)
+    M = nbr_of_modes(c)
     spatial_indices = first_labels(c)
     @assert length(cell(first(spatial_indices), c)) == 2 "Each unit cell should have two fermions for this hamiltonian"
     N = div(M, 2)
@@ -122,7 +122,7 @@ end
 
 
 function TSL_hamiltonian(c::AbstractBasis; μL, μC, μR, h, t, Δ, U, tsoc)
-    @assert nbr_of_fermions(c) == 6 "This basis has the wrong number of fermions for this hamiltonian $(nbr_of_fermions(c)) != 6"
+    @assert nbr_of_modes(c) == 6 "This basis has the wrong number of fermions for this hamiltonian $(nbr_of_modes(c)) != 6"
     fermions = [(c[j, :↑], c[j, :↓]) for j in (:L, :C, :R)]
     TSL_hamiltonian(fermions...; μL, μC, μR, h, t, Δ, U, tsoc)
 end

--- a/src/phase_factors.jl
+++ b/src/phase_factors.jl
@@ -178,7 +178,7 @@ end
     partitions = [[[3, 2, 7, 5, 1], [4, 6]], [[7, 3, 2], [1, 5], [4, 6]]]
     for p in partitions
         subinds = map(p -> Tuple(siteindices(p, jw)), p)
-        N = length(jw)
+        local N = length(jw)
         @test h(p, fockstates, jw) == phf(fockstates, subinds, N)
     end
 

--- a/src/qubit.jl
+++ b/src/qubit.jl
@@ -60,6 +60,8 @@ get_fockstates(::QubitBasis{M,<:Any,NoSymmetry}) where {M} = Iterators.map(FockN
 get_fockstates(b::QubitBasis) = get_fockstates(b.symmetry)
 use_partial_trace_phase_factors(b1::QubitBasis, b2::QubitBasis) = false
 use_partial_transpose_phase_factors(::QubitBasis) = false
+use_wedge_phase_factors(bs, b::QubitBasis) = false
+
 nbr_of_modes(::QubitBasis{M}) where {M} = M
 
 function bloch_vector(ρ::AbstractMatrix, label, basis::QubitBasis)

--- a/src/qubit.jl
+++ b/src/qubit.jl
@@ -99,15 +99,16 @@ end
     @test c2 == Bspin[1, :↓]
 
     a = QubitBasis(1:3)
+    as = (QubitBasis(1:1), QubitBasis(2:2), QubitBasis(3:3))
     @test all(f == a[n] for (n, f) in enumerate(a))
     v = [QuantumDots.indtofock(i, a) for i in 1:8]
-    t1 = QuantumDots.tensor(v, a)
+    t1 = reshape(v, a, as)
     t2 = [i1 + 2i2 + 4i3 for i1 in (0, 1), i2 in (0, 1), i3 in (0, 1)]
     @test t1 == FockNumber.(t2)
 
-    a = QubitBasis(1:3; qn=QuantumDots.parity)
+    a = QubitBasis(1:3; qn=ParityConservation())
     v = [QuantumDots.indtofock(i, a) for i in 1:8]
-    t1 = QuantumDots.tensor(v, a)
+    t1 = reshape(v, a, as)
     t2 = [i1 + 2i2 + 4i3 for i1 in (0, 1), i2 in (0, 1), i3 in (0, 1)]
     @test t1 == FockNumber.(t2)
 

--- a/src/qubit.jl
+++ b/src/qubit.jl
@@ -61,6 +61,7 @@ get_fockstates(b::QubitBasis) = get_fockstates(b.symmetry)
 use_partial_trace_phase_factors(b1::QubitBasis, b2::QubitBasis) = false
 use_partial_transpose_phase_factors(::QubitBasis) = false
 use_wedge_phase_factors(bs, b::QubitBasis) = false
+use_reshape_phase_factors(b::QubitBasis, bs) = false
 
 nbr_of_modes(::QubitBasis{M}) where {M} = M
 
@@ -111,7 +112,9 @@ end
     @test t1 == FockNumber.(t2)
 
     v2 = rand(8)
-    @test sort(QuantumDots.svd(v2, (1,), a).S .^ 2) ≈ eigvals(partial_trace(v2, a, QubitBasis(1:1)))
+    a1 = QubitBasis(1:1)
+    a2 = QubitBasis(2:3)
+    @test sort(svdvals(reshape(v2, a, (a1, a2))) .^ 2) ≈ eigvals(partial_trace(v2, a, a1))
 
     c = QubitBasis(1:2, (:a, :b))
     cparity = QubitBasis(1:2, (:a, :b); qn=QuantumDots.parity)

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -62,7 +62,7 @@ symmetry(b::FermionBasis) = b.symmetry
 
 handle_labels(iter, iters...) = Base.product(iter, iters...)
 handle_labels(iter) = iter
-nbr_of_fermions(::FermionBasis{M}) where {M} = M
+nbr_of_modes(::FermionBasis{M}) where {M} = M
 
 function Base.:(==)(b1::FermionBasis, b2::FermionBasis)
     if b1 === b2
@@ -135,7 +135,7 @@ Constructs a sparse vector representation of a `BdGFermion` object.
 """
 function rep(f::BdGFermion)
     b = basis(f)
-    N = nbr_of_fermions(b)
+    N = nbr_of_modes(b)
     sparsevec([indexpos(f, b)], f.amp, 2N)
 end
 """
@@ -162,10 +162,10 @@ struct FermionBdGBasis{M,L} <: AbstractBasis
     end
 end
 FermionBdGBasis(labels...) = FermionBdGBasis(collect(Base.product(labels...)))
-nbr_of_fermions(::FermionBdGBasis{M}) where {M} = M
+nbr_of_modes(::FermionBdGBasis{M}) where {M} = M
 Base.getindex(b::FermionBdGBasis, i) = BdGFermion(i, b)
 Base.getindex(b::FermionBdGBasis, args...) = BdGFermion(args, b)
-indexpos(f::BdGFermion, b::FermionBdGBasis) = b.position[f.id] + !f.hole * nbr_of_fermions(b)
+indexpos(f::BdGFermion, b::FermionBdGBasis) = b.position[f.id] + !f.hole * nbr_of_modes(b)
 
 Base.iterate(b::FermionBdGBasis) = ((result, state) = iterate(keys(b.position)); (b[result], state));
 Base.iterate(b::FermionBdGBasis, state) = (res = iterate(keys(b.position), state); isnothing(res) ? nothing : (b[res[1]], res[2]))

--- a/src/symbolics/symbolic_majoranas.jl
+++ b/src/symbolics/symbolic_majoranas.jl
@@ -138,12 +138,12 @@ TermInterface.children(a::MajoranaSym) = arguments(a)
 
     r = (@rule ~x::(x -> x isa QuantumDots.AbstractFermionSym) => (~x).basis[min((~x).label + 1, 10)])
     @test r(f[1]) == f[2]
-    @test simplify(f[1], r) == f[10] # applies rule repeatedly until no change
+    @test simplify(f[1]; rewriter=r) == f[10] # applies rule repeatedly until no change
     r2 = Rewriters.Prewalk(Rewriters.PassThrough(r)) # should work on composite expressions. Postwalk also works.
     @test r2(2 * f[2]) == 2f[3]
-    @test simplify(2f[1], r2) == 2f[10]
+    @test simplify(2f[1]; rewriter=r2) == 2f[10]
     @test r2(2 * f[1] * f[2] + f[3]) == 2 * f[2] * f[3] + f[4]
-    @test simplify(2 * f[1]' * f[2] + f[3], r2) == 2 * f[10]' * f[10] + f[10]
+    @test simplify(2 * f[1]' * f[2] + f[3]; rewriter=r2) == 2 * f[10]' * f[10] + f[10]
 end
 
 @testitem "Rewrite rules" begin

--- a/src/wedge.jl
+++ b/src/wedge.jl
@@ -337,8 +337,8 @@ end
     @test canonical_embedding(A, cX, c) * canonical_embedding(B, cX, c) ≈ canonical_embedding(A * B, cX, c)
     for cmode in modebases
         #Eq 5bl
-        A = rand(ComplexF64, 2, 2)
-        B = rand(ComplexF64, 2, 2)
+        local A = rand(ComplexF64, 2, 2)
+        local B = rand(ComplexF64, 2, 2)
         @test fermionic_embedding(A, cmode, c) * fermionic_embedding(B, cmode, c) ≈ fermionic_embedding(A * B, cmode, c)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,15 +77,16 @@ end
     @test c2 == Bspin[1, :↓]
 
     a = FermionBasis(1:3)
+    as = (FermionBasis(1:1), FermionBasis(2:2), FermionBasis(3:3))
     @test all(f == a[n] for (n, f) in enumerate(a))
     v = [QuantumDots.indtofock(i, a) for i in 1:8]
-    t1 = QuantumDots.tensor(v, a)
+    t1 = reshape(v, a, as)
     t2 = [i1 + 2i2 + 4i3 for i1 in (0, 1), i2 in (0, 1), i3 in (0, 1)]
     @test t1 == FockNumber.(t2)
 
     a = FermionBasis(1:3; qn=QuantumDots.parity)
     v = [QuantumDots.indtofock(i, a) for i in 1:8]
-    t1 = QuantumDots.tensor(v, a)
+    t1 = reshape(v, a, as)
     t2 = [i1 + 2i2 + 4i3 for i1 in (0, 1), i2 in (0, 1), i3 in (0, 1)]
     @test t1 == FockNumber.(t2)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,9 +51,9 @@ end
     Random.seed!(1234)
     N = 2
     B = FermionBasis(1:N)
-    @test QuantumDots.nbr_of_fermions(B) == N
+    @test QuantumDots.nbr_of_modes(B) == N
     Bspin = FermionBasis(1:N, (:↑, :↓); qn=QuantumDots.fermionnumber)
-    @test QuantumDots.nbr_of_fermions(Bspin) == 2N
+    @test QuantumDots.nbr_of_modes(Bspin) == 2N
     @test B[1] isa SparseMatrixCSC
     @test Bspin[1, :↑] isa SparseMatrixCSC
     @test parityoperator(B) isa SparseMatrixCSC
@@ -100,7 +100,7 @@ end
     end
     function bilinear_equality(c, csub, ρ)
         subsystem = Tuple(keys(csub))
-        ρsub = partial_trace(ρ, csub, c)
+        ρsub = partial_trace(ρ, c, csub)
         @test tr(ρsub) ≈ 1
         all((tr(op1 * ρ) ≈ tr(op2 * ρsub)) for (op1, op2) in zip(bilinears(c, subsystem), bilinears(csub, subsystem)))
     end
@@ -140,14 +140,15 @@ end
     G2 = (opdm_bdg[[1, 2, 1 + N, 2 + N], [1, 2, 1 + N, 2 + N]])
     G3 = (opdm_bdg[[1, 2, 3, 1 + N, 2 + N, 3 + N], [1, 2, 3, 1 + N, 2 + N, 3 + N]])
     G13 = (opdm_bdg[[1, 3, 1 + N, 3 + N], [1, 3, 1 + N, 3 + N]])
-    @test norm(partial_trace(gs, (1,), c)) ≈ norm(one_particle_density_matrix(gs * gs', c, (1,))) ≈ norm(G1)
+    c1 = FermionBasis(1:1)
+    @test norm(partial_trace(gs, c, c1)) ≈ norm(one_particle_density_matrix(gs * gs', c, (1,))) ≈ norm(G1)
     @test one_particle_density_matrix(gs * gs', c, (1, 2)) ≈ G2
     @test one_particle_density_matrix(gs * gs', c, (1, 2, 3)) == one_particle_density_matrix(gs * gs', c) ≈ G3
 
-    reduced_density_matrix = partial_trace(gs, (1,), c)
-    reduced_density_matrix2 = partial_trace(gs, (1, 2), c)
-    reduced_density_matrix3 = partial_trace(gs, (1, 2, 3), c)
-    reduced_density_matrix13 = partial_trace(gs, (1, 3), c)
+    reduced_density_matrix = partial_trace(gs, c, FermionBasis((1,)))
+    reduced_density_matrix2 = partial_trace(gs, c, FermionBasis((1, 2)))
+    reduced_density_matrix3 = partial_trace(gs, c, FermionBasis((1, 2, 3)))
+    reduced_density_matrix13 = partial_trace(gs, c, FermionBasis((1, 3)))
     c1 = FermionBasis(1:1)
     c12 = FermionBasis(1:2)
     @test reduced_density_matrix ≈ many_body_density_matrix(G1, c1)
@@ -188,14 +189,14 @@ end
         c23 = FermionBasis(2:3; qn)
         γ = Hermitian([0I rand(ComplexF64, 4, 4); rand(ComplexF64, 4, 4) 0I])
         f = c[1]
-        @test tr(c1[1] * partial_trace(γ, c1, c)) ≈ tr(f * γ)
-        @test tr(c12[1] * partial_trace(γ, c12, c)) ≈ tr(f * γ)
-        @test tr(c13[1] * partial_trace(γ, c13, c)) ≈ tr(f * γ)
+        @test tr(c1[1] * partial_trace(γ, c, c1,)) ≈ tr(f * γ)
+        @test tr(c12[1] * partial_trace(γ, c, c12,)) ≈ tr(f * γ)
+        @test tr(c13[1] * partial_trace(γ, c, c13,)) ≈ tr(f * γ)
 
         f = c[2]
-        @test tr(c2[2] * partial_trace(γ, c2, c)) ≈ tr(f * γ)
-        @test tr(c12[2] * partial_trace(γ, c12, c)) ≈ tr(f * γ)
-        @test tr(c23[2] * partial_trace(γ, c23, c)) ≈ tr(f * γ)
+        @test tr(c2[2] * partial_trace(γ, c, c2)) ≈ tr(f * γ)
+        @test tr(c12[2] * partial_trace(γ, c, c12)) ≈ tr(f * γ)
+        @test tr(c23[2] * partial_trace(γ, c, c23)) ≈ tr(f * γ)
     end
 end
 
@@ -564,7 +565,7 @@ end
 
     N = 5
     params = rand(3)
-    hamiltonian(a, μ, t, Δ) = μ * sum(a[i]'a[i] for i in 1:QuantumDots.nbr_of_fermions(a)) + t * (a[1]'a[2] + a[2]'a[1]) + Δ * (a[1]'a[2]' + a[2]a[1])
+    hamiltonian(a, μ, t, Δ) = μ * sum(a[i]'a[i] for i in 1:QuantumDots.nbr_of_modes(a)) + t * (a[1]'a[2] + a[2]'a[1]) + Δ * (a[1]'a[2]' + a[2]a[1])
 
     a = FermionBasis(1:N)
     hamiltonian(params...) = hamiltonian(a, params...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -565,10 +565,10 @@ end
 
     N = 5
     params = rand(3)
-    hamiltonian(a, μ, t, Δ) = μ * sum(a[i]'a[i] for i in 1:QuantumDots.nbr_of_modes(a)) + t * (a[1]'a[2] + a[2]'a[1]) + Δ * (a[1]'a[2]' + a[2]a[1])
+    _hamiltonian(a, μ, t, Δ) = μ * sum(a[i]'a[i] for i in 1:QuantumDots.nbr_of_modes(a)) + t * (a[1]'a[2] + a[2]'a[1]) + Δ * (a[1]'a[2]' + a[2]a[1])
 
     a = FermionBasis(1:N)
-    hamiltonian(params...) = hamiltonian(a, params...)
+    hamiltonian= Base.Fix1(_hamiltonian, a)
     fastham! = QuantumDots.fastgenerator(hamiltonian, 3)
     mat = hamiltonian((2 .* params)...)
     fastham!(mat, params...)
@@ -576,7 +576,7 @@ end
 
     #parity conservation
     a = FermionBasis(1:N; qn=QuantumDots.parity)
-    hamiltonian(params...) = hamiltonian(a, params...)
+    hamiltonian = Base.Fix1(_hamiltonian, a)
     parityham! = QuantumDots.fastgenerator(hamiltonian, 3)
     mat = hamiltonian((2 .* params)...)
     parityham!(mat, params...)
@@ -605,7 +605,7 @@ end
 
     #number conservation
     a = FermionBasis(1:N; qn=QuantumDots.fermionnumber)
-    hamiltonian(params...) = hamiltonian(a, params...)
+    hamiltonian = Base.Fix1(_hamiltonian, a)
 
     numberham! = QuantumDots.fastgenerator(hamiltonian, 3)
     mat = hamiltonian((2 .* params)...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -568,7 +568,7 @@ end
     _hamiltonian(a, μ, t, Δ) = μ * sum(a[i]'a[i] for i in 1:QuantumDots.nbr_of_modes(a)) + t * (a[1]'a[2] + a[2]'a[1]) + Δ * (a[1]'a[2]' + a[2]a[1])
 
     a = FermionBasis(1:N)
-    hamiltonian= Base.Fix1(_hamiltonian, a)
+    hamiltonian(params...) = _hamiltonian(a, params...)
     fastham! = QuantumDots.fastgenerator(hamiltonian, 3)
     mat = hamiltonian((2 .* params)...)
     fastham!(mat, params...)
@@ -576,7 +576,7 @@ end
 
     #parity conservation
     a = FermionBasis(1:N; qn=QuantumDots.parity)
-    hamiltonian = Base.Fix1(_hamiltonian, a)
+    hamiltonian(params...) = _hamiltonian(a, params...)
     parityham! = QuantumDots.fastgenerator(hamiltonian, 3)
     mat = hamiltonian((2 .* params)...)
     parityham!(mat, params...)
@@ -605,7 +605,7 @@ end
 
     #number conservation
     a = FermionBasis(1:N; qn=QuantumDots.fermionnumber)
-    hamiltonian = Base.Fix1(_hamiltonian, a)
+    hamiltonian(params...) = _hamiltonian(a, params...)
 
     numberham! = QuantumDots.fastgenerator(hamiltonian, 3)
     mat = hamiltonian((2 .* params)...)


### PR DESCRIPTION
This is breaking. Reorders the arguments in partial_trace and partial_transpose. For partial_trace, only accepts a basis for the subsystem, not labels.
partial_trace(m,bfull,bsub) is the new convention, to be more consistent with other methods. The logic for (hopefully) all the methods now is that the first basis corresponds to the input array and the second one to the output.